### PR TITLE
Add sett preset to surface.json

### DIFF
--- a/data/fields/surface.json
+++ b/data/fields/surface.json
@@ -12,6 +12,7 @@
             "compacted": "Compacted",
             "concrete": "Concrete",
             "paving_stones": "Paving Stones",
+            "sett": "Sett",
             "dirt": "Dirt",
             "grass": "Grass",
             "sand": "Sand",


### PR DESCRIPTION
Streets with "sett" surface" [are very common in Europe](https://taginfo.openstreetmap.org/tags/surface=sett#map).
Many streets are also tagged "cobblestone" since that vague tag was used before sett.
Translating sett would allow more tagging with it and make it easier for non-English speaking users to fix streets tagged with cobblestone.